### PR TITLE
`body` may be undefined, and it would crash

### DIFF
--- a/index.js
+++ b/index.js
@@ -110,6 +110,7 @@ function handleUncompressed(res, _write, _end, callback) {
     try {
       body = JSON.parse(buffer.toBuffer().toString());
     } catch (e) {
+      body = buffer.toBuffer().toString();
       console.log('JSON.parse error:', e);
     }
 
@@ -126,13 +127,11 @@ function handleUncompressed(res, _write, _end, callback) {
       _write.call(res, body);
       _end.call(res);
     };
-
+    
     if (body && body.then) {
       body.then(finish);
-    } else if (body !== undefined) {
-      finish(body);
     } else {
-      console.log('No response!');
+      finish(body);
     }
   };
 }

--- a/index.js
+++ b/index.js
@@ -129,8 +129,10 @@ function handleUncompressed(res, _write, _end, callback) {
 
     if (body && body.then) {
       body.then(finish);
-    } else {
+    } else if (body !== undefined) {
       finish(body);
+    } else {
+      console.log('No response!');
     }
   };
 }

--- a/index.js
+++ b/index.js
@@ -127,7 +127,7 @@ function handleUncompressed(res, _write, _end, callback) {
       _write.call(res, body);
       _end.call(res);
     };
-    
+
     if (body && body.then) {
       body.then(finish);
     } else {


### PR DESCRIPTION
Add this condition, it will be like this:
JSON.parse error: SyntaxError: Unexpected token < in JSON at position 0
    at JSON.parse (<anonymous>)
    at ServerResponse.res.end (xxx\node_modules\node-http-proxy-json\index.js:111:19)
    at IncomingMessage.onend (_stream_readable.js:598:10)
    at Object.onceWrapper (events.js:314:30)
    at emitNone (events.js:110:20)
    at IncomingMessage.emit (events.js:207:7)
    at endReadableNT (_stream_readable.js:1059:12)
    at _combinedTickCallback (internal/process/next_tick.js:138:11)
    at process._tickCallback (internal/process/next_tick.js:180:9)
No response!

At least, it won't crash!